### PR TITLE
Add copy-encrypted-ami link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,7 @@ Inspired by how `git` runs helper tools, bigriver-tools includes a driver script
 * [cloudformation-plus](https://github.com/HewlettPackard/cloudformation-plus/) - Python library that adds features to AWS CloudFormation that reduce the amount of code you must write in order to automate the deployment of non-trivial cloud-based systems. Specifically, this library adds elements to the CloudFormation template language that perform tasks that otherwise would need to be done in your deploy script.
 * [cloud-custodian](https://github.com/capitalone/cloud-custodian) - Cloud Custodian can be used to manage AWS accounts by ensuring real time compliance to security policies (like encryption and access requirements), tag policies, and cost management via garbage collection of unused resources and off-hours resource management.
 * [cloud-nuke](https://github.com/gruntwork-io/cloud-nuke) - A tool for cleaning up an AWS account by nuking (deleting) all resources within it.
+* [copy-encrypted-ami](https://github.com/aws-samples/copy-encrypted-ami) - Automate copying encrypted AMIs across accounts and regions.
 * [cw](https://github.com/lucagrulla/cw) - Tail AWS Cloudwatch Logs so you can `grep` them.
 * [delete-bucket](https://github.com/tantona/delete-bucket) - CLI tool for deleting versioned AWS S3 Buckets.
 * [ebs-snapshooter](https://github.com/smileisak/ebs-snapshooter) - Python tool to snapshot all your aws-ebs volumes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# Description

* Add copy-encrypted-ami link

# Rights

- [x] This repository is covered by the Apache 2.0 license (except where noted in individual scripts' source), and I agree that this PR contribution is also subject to the Apache 2.0 license.

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Adding utility script(s)
- [x] Adding link(s) to external resources
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation Changes
- [ ] Test updates

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask on Slack -->

## General
- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated Readme.md to give credit to the script author
- [ ] I have updated Readme.md to describe what the script does
- [ ] If a new script is not using an Apache 2.0 license, there's a link in the script source saying what license it _is_ under.

## Scripts
- [ ] I have run `pylint` on all python files touched in my branch.
- [ ] I have run `rubocop` on all ruby files touched in my branch.
- [ ] I have run `shellcheck` on all shell scripts touched in my branch.
- [ ] All scripts touched/added in this PR have valid shebang lines and are marked executable. 
- [ ] Any scripts added in my PR do not include language extensions in their names - no `foo.sh`, `foo.rb` or `foo.py`. We do not want to have to change other scripts just because something gets rewritten in a better fitting language.
